### PR TITLE
Load modif

### DIFF
--- a/nginx.conf
+++ b/nginx.conf
@@ -1,0 +1,32 @@
+worker_processes 1;
+
+events {
+    worker_connections 1024;
+}
+
+http {
+    upstream browserquest_backend {
+
+        server localhost:8001;
+        server localhost:8002;
+        server localhost:8003;
+        server localhost:8004;
+        server localhost:8005;
+    }
+
+    server {
+        listen 8000;
+
+        location / {
+            proxy_pass http://browserquest_backend;
+            proxy_http_version 1.1;
+            proxy_set_header Upgrade $http_upgrade;
+            proxy_set_header Connection "upgrade";
+            proxy_set_header Host $host;
+        }
+         location /status {
+                proxy_pass http://browserquest_backend;
+                }
+    }
+}
+

--- a/nginx.conf
+++ b/nginx.conf
@@ -6,7 +6,6 @@ events {
 
 http {
     upstream browserquest_backend {
-
         server localhost:8001;
         server localhost:8002;
         server localhost:8003;

--- a/server/config_8001.json
+++ b/server/config_8001.json
@@ -1,0 +1,9 @@
+{
+  "host": "127.0.0.1",
+  "port": 8001,
+  "debug_level": "debug",
+  "nb_players_per_world": 200,
+  "nb_worlds": 1,
+  "map_filepath": "./server/maps/world_server.json",
+  "metrics_enabled": false
+}

--- a/server/config_8001.json
+++ b/server/config_8001.json
@@ -3,7 +3,7 @@
   "port": 8001,
   "debug_level": "debug",
   "nb_players_per_world": 200,
-  "nb_worlds": 1,
+  "nb_worlds": 5,
   "map_filepath": "./server/maps/world_server.json",
   "metrics_enabled": false
 }

--- a/server/config_8002.json
+++ b/server/config_8002.json
@@ -1,0 +1,9 @@
+{
+  "host": "127.0.0.1",
+  "port": 8002,
+  "debug_level": "debug",
+  "nb_players_per_world": 200,
+  "nb_worlds": 2,
+  "map_filepath": "./server/maps/world_server.json",
+  "metrics_enabled": false
+}

--- a/server/config_8002.json
+++ b/server/config_8002.json
@@ -3,7 +3,7 @@
   "port": 8002,
   "debug_level": "debug",
   "nb_players_per_world": 200,
-  "nb_worlds": 2,
+  "nb_worlds": 5,
   "map_filepath": "./server/maps/world_server.json",
   "metrics_enabled": false
 }

--- a/server/config_8003.json
+++ b/server/config_8003.json
@@ -1,0 +1,9 @@
+{
+  "host": "127.0.0.1",
+  "port": 8003,
+  "debug_level": "debug",
+  "nb_players_per_world": 200,
+  "nb_worlds": 3,
+  "map_filepath": "./server/maps/world_server.json",
+  "metrics_enabled": false
+}

--- a/server/config_8003.json
+++ b/server/config_8003.json
@@ -3,7 +3,7 @@
   "port": 8003,
   "debug_level": "debug",
   "nb_players_per_world": 200,
-  "nb_worlds": 3,
+  "nb_worlds": 5,
   "map_filepath": "./server/maps/world_server.json",
   "metrics_enabled": false
 }

--- a/server/config_8004.json
+++ b/server/config_8004.json
@@ -1,0 +1,9 @@
+{
+  "host": "127.0.0.1",
+  "port": 8004,
+  "debug_level": "debug",
+  "nb_players_per_world": 200,
+  "nb_worlds": 4,
+  "map_filepath": "./server/maps/world_server.json",
+  "metrics_enabled": false
+}

--- a/server/config_8004.json
+++ b/server/config_8004.json
@@ -3,7 +3,7 @@
   "port": 8004,
   "debug_level": "debug",
   "nb_players_per_world": 200,
-  "nb_worlds": 4,
+  "nb_worlds": 5,
   "map_filepath": "./server/maps/world_server.json",
   "metrics_enabled": false
 }

--- a/server/config_8005.json
+++ b/server/config_8005.json
@@ -1,0 +1,9 @@
+{
+  "host": "127.0.0.1",
+  "port": 8005,
+  "debug_level": "debug",
+  "nb_players_per_world": 200,
+  "nb_worlds": 5,
+  "map_filepath": "./server/maps/world_server.json",
+  "metrics_enabled": false
+}


### PR DESCRIPTION
This pull request includes several changes to configure an Nginx server and set up multiple server configurations for load balancing. The most important changes include adding the Nginx configuration and creating configuration files for five backend servers.

Nginx configuration:

* [`nginx.conf`](diffhunk://#diff-1f91f64bfa3fb0a1ece881887af0a2356b8c529a96fb91c1894745b2a1a009aaR1-R31): Added configuration to set up Nginx with one worker process, defined worker connections, and configured an upstream block with five backend servers. Added server configuration to listen on port 8000 and proxy requests to the backend servers.

Backend server configurations:

* [`server/config_8001.json`](diffhunk://#diff-c42fdb0ffc36104c85ced44a602b90723a08889116aefe8461c51c61924ed160R1-R9): Created configuration file for backend server running on port 8001 with specified settings including debug level, number of players per world, and map file path.
* [`server/config_8002.json`](diffhunk://#diff-a064398b13469b091c176b6fec545f46ef840944a54fe2a6b6332039cce1d361R1-R9): Created configuration file for backend server running on port 8002 with similar settings as the first backend server.
* [`server/config_8003.json`](diffhunk://#diff-c7ebc0746697c51df1dc7ff294fe7e1525bd72e896f811a0f6a9dca9a8f7c7f2R1-R9): Created configuration file for backend server running on port 8003 with similar settings as the first backend server.
* [`server/config_8004.json`](diffhunk://#diff-3dd055e5819dde4a865a1f8a2415cee90ba5fbe63c9606d4df6ddb87b76f2854R1-R9): Created configuration file for backend server running on port 8004 with similar settings as the first backend server.
* [`server/config_8005.json`](diffhunk://#diff-7e18869e9e34c75a06d7b8a4a061be7f04d4522d2d008a6d8ce93b3d9cde6214R1-R9): Created configuration file for backend server running on port 8005 with similar settings as the first backend server.